### PR TITLE
Fix/Manager Crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "com.huhx0015.huhxagse"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/hxaudio/build.gradle
+++ b/hxaudio/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 25
         versionCode 11
-        versionName "3.1.9"
+        versionName "3.2.0"
     }
     buildTypes {
         release {

--- a/hxaudio/src/main/java/com/huhx0015/hxaudio/utils/HXAudioPlayerUtils.java
+++ b/hxaudio/src/main/java/com/huhx0015/hxaudio/utils/HXAudioPlayerUtils.java
@@ -22,22 +22,22 @@ public class HXAudioPlayerUtils {
 
         // ANDROID 2.3 - ANDROID 6.0:
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            AudioManager manager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+            if (manager != null) {
 
-            AudioManager mgr = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-
-            // ANDROID 6.0+:
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-
-                if (mode) {
-                    mgr.adjustStreamVolume(AudioManager.STREAM_SYSTEM, AudioManager.ADJUST_UNMUTE, 0);
-                } else {
-                    mgr.adjustStreamVolume(AudioManager.STREAM_SYSTEM, AudioManager.ADJUST_MUTE, 0);
+                // ANDROID 6.0+:
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    if (mode) {
+                        manager.adjustStreamVolume(AudioManager.STREAM_SYSTEM, AudioManager.ADJUST_UNMUTE, 0);
+                    } else {
+                        manager.adjustStreamVolume(AudioManager.STREAM_SYSTEM, AudioManager.ADJUST_MUTE, 0);
+                    }
                 }
-            }
 
-            // ANDROID 2.3 - ANDROID 5.1:
-            else {
-                mgr.setStreamMute(AudioManager.STREAM_SYSTEM, mode);
+                // ANDROID 2.3 - ANDROID 5.1:
+                else {
+                    manager.setStreamMute(AudioManager.STREAM_SYSTEM, mode);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed a null pointer exception issue when initializing the AudioManager object in HXAudioPlayerUtils class.

> Caused by java.lang.NullPointerException
       at android.os.Parcel.readException(Parcel.java:1483)
       at android.os.Parcel.readException(Parcel.java:1427)
       at android.media.IAudioService$Stub$Proxy.setStreamMute(IAudioService.java:1115)
       at android.media.AudioManager.setStreamMute(AudioManager.java:985)
       at com.huhx0015.hxaudio.utils.HXAudioPlayerUtils.enableSystemSound(HXAudioPlayerUtils.java:40)
       at com.ycorner.dragongeo.Activities.DQTitleScreen.onResume(DQTitleScreen.java:176)
       at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1192)
       at android.app.Activity.performResume(Activity.java:5310)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2826)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:2865)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2291)
       at android.app.ActivityThread.access$800(ActivityThread.java:144)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1246)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:212)
       at android.app.ActivityThread.main(ActivityThread.java:5137)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:515)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:902)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:718)
       at 

> dalvik.system.NativeStart.main(NativeStart.java)
